### PR TITLE
Fix nfp link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The basic interface works as follows, where `predict` expects a list of SMILES s
 ```
 
 The model breaks all single, non-cyclic bonds in the input molecules and calculates their bond dissociation energies. Typical prediction errors are less than 1 kcal/mol. 
-The model is based on Tensorflow (2.x), and makes heavy use of the [neural fingerprint](github.com/NREL/nfp) library (0.1.x).
+The model is based on Tensorflow (2.x), and makes heavy use of the [neural fingerprint](https://github.com/NREL/nfp) library (0.1.x).
 
 For additional details, see the publication:
 St. John, P. C., Guan, Y., Kim, Y., Kim, S., & Paton, R. S. (2020). Prediction of organic homolytic bond dissociation enthalpies at near chemical accuracy with sub-second computational cost. Nature Communications, 11(1). doi:10.1038/s41467-020-16201-z


### PR DESCRIPTION
The link treated `GitHub.com` as a repository folder, this sgould fix it.